### PR TITLE
Call success data before handle success

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,5 +71,5 @@
     "test": "yarn jest --env=jsdom ./src",
     "watch": "nodemon --watch src --exec \"npm run compile\""
   },
-  "version": "2.6.1"
+  "version": "2.7.0"
 }

--- a/src/handleApiError.js
+++ b/src/handleApiError.js
@@ -1,5 +1,5 @@
 import { failData } from 'fetch-normalize-data'
-import { put, select } from 'redux-saga/effects'
+import { call, put, select } from 'redux-saga/effects'
 
 export function *handleApiError(payload, config) {
   const { handleFail } = config
@@ -9,7 +9,7 @@ export function *handleApiError(payload, config) {
   if (handleFail) {
     const state = yield select(s => s)
     const sucessAction = { config, payload }
-    handleFail(state, sucessAction)
+    yield call(handleFail,state, sucessAction)
   }
 
 }

--- a/src/handleApiSuccess.js
+++ b/src/handleApiSuccess.js
@@ -1,17 +1,16 @@
 import { successData } from 'fetch-normalize-data'
-import { put, select } from 'redux-saga/effects'
+import { call, put, select } from 'redux-saga/effects'
 
 export function *handleApiSuccess(payload, config) {
   const { handleSuccess } = config
 
+  yield put(successData(payload, config))
+
   if (handleSuccess) {
     const state = yield select(s => s)
     const sucessAction = { config, payload }
-    handleSuccess(state, sucessAction)
+    yield call(handleSuccess, state, sucessAction)
   }
-
-  yield put(successData(payload, config))
-
 }
 
 export default handleApiSuccess

--- a/src/handleResultError.js
+++ b/src/handleResultError.js
@@ -1,5 +1,5 @@
 import { failData } from 'fetch-normalize-data'
-import { put, select } from 'redux-saga/effects'
+import { call, put, select } from 'redux-saga/effects'
 
 export const GLOBAL_RESULT_ERROR = 'Result returned by the server is not at the good json format'
 
@@ -19,7 +19,7 @@ export function *handleResultError (config) {
   if (handleFail) {
     const state = yield select(s => s)
     const failAction = { config, payload }
-    handleFail(state, { payload })
+    yield call(handleFail, state, failAction)
   }
 
   throw Error(errors)

--- a/src/handleServerError.js
+++ b/src/handleServerError.js
@@ -1,5 +1,5 @@
 import { failData } from 'fetch-normalize-data'
-import { put, select } from 'redux-saga/effects'
+import { call, put, select } from 'redux-saga/effects'
 
 export const GLOBAL_SERVER_ERROR = 'Server error. Try to to refresh the page.'
 
@@ -22,7 +22,7 @@ export function *handleServerError (error, config) {
   if (handleFail) {
     const state = yield select(s => s)
     const failAction = { config, payload  }
-    handleFail(state, failAction)
+    yield call(handleFail, state, failAction)
   }
 }
 

--- a/src/handleTimeoutError.js
+++ b/src/handleTimeoutError.js
@@ -1,5 +1,5 @@
 import { failData } from 'fetch-normalize-data'
-import { put, select } from 'redux-saga/effects'
+import { call, put, select } from 'redux-saga/effects'
 
 export const GLOBAL_TIMEOUT_ERROR = 'Server timeout'
 
@@ -19,7 +19,7 @@ export function *handleTimeoutError (config) {
   if (handleFail) {
     const state = yield select(s => s)
     const failAction = { config, payload }
-    handleFail(state, failAction)
+    yield call(handleFail, state, failAction)
   }
 
   throw Error(errors)


### PR DESCRIPTION
ça permet de faire que le state passé dans handleSuccess(state, action) soit deja avec la version rafraîchie du state.data grâce au nouveau payload, ce qui semble plus logique.